### PR TITLE
chore(deps): delay Dependabot updates for 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'monday'
+    cooldown:
+      default-days: 7
     assignees:
       - 'the3ash'
     commit-message:
@@ -41,6 +43,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'monday'
+    cooldown:
+      default-days: 7
     assignees:
       - 'the3ash'
     commit-message:


### PR DESCRIPTION
## What changed

- Set `cooldown.default-days` to 7 for npm version updates.
- Set the same 7-day cooldown for GitHub Actions version updates.

## Why

This avoids adopting newly released dependency versions during their first week, reducing update PR failures caused by fresh regressions or ecosystem lag. Dependabot security updates are not delayed by `cooldown`.

## Checks

- Parsed `.github/dependabot.yml` successfully.
- Verified both update entries resolve to `default-days: 7`.
- Ran `git diff --check`.
